### PR TITLE
chore(root): rebrand the project to nexuskit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Multi-Tenant Microservice Architecture
+# NexusKit: The Complete Microservices Toolkit
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-green.svg)](https://nodejs.org/)
@@ -6,7 +6,7 @@
 [![NestJS](https://img.shields.io/badge/NestJS-10.0+-red.svg)](https://nestjs.com/)
 [![Nx](https://img.shields.io/badge/Nx-17.0+-purple.svg)](https://nx.dev/)
 
-A production-ready, enterprise-grade microservice architecture foundation built with NestJS and Nx. This framework provides a robust, scalable, and maintainable foundation for building distributed systems with built-in service discovery, load balancing, dynamic scaling, and multi-tenancy support.
+A production-ready, enterprise-grade microservices toolkit built with NestJS and Nx. NexusKit provides a robust, scalable, and maintainable foundation for building distributed systems with built-in service discovery, load balancing, dynamic scaling, multi-tenancy support, and extensible libraries for CQRS, gRPC, GraphQL, resilience, and more.
 
 ## 🚀 Features
 
@@ -64,27 +64,27 @@ This project follows a modular microservice architecture with the following key 
 
 ### Key Libraries
 
-- **`@swft-mt/bootstrap`**: Configuration management with file-based loading
-- **`@swft-mt/client`**: Declarative HTTP service clients with service discovery
-- **`@swft-mt/cloud`**: Cloud-native service abstractions and registry management
-- **`@swft-mt/common`**: Shared utilities, interfaces, and common functionality
-- **`@swft-mt/consul`**: Consul integration for service discovery and health checks
-- **`@swft-mt/loadbalancer`**: Configurable load balancing with multiple strategies
-- **`@swft-mt/zookeeper`**: ZooKeeper integration for service discovery and registry
+- **`@nexuskit/bootstrap`**: Configuration management with file-based loading
+- **`@nexuskit/client`**: Declarative HTTP service clients with service discovery
+- **`@nexuskit/cloud`**: Cloud-native service abstractions and registry management
+- **`@nexuskit/common`**: Shared utilities, interfaces, and common functionality
+- **`@nexuskit/consul`**: Consul integration for service discovery and health checks
+- **`@nexuskit/loadbalancer`**: Configurable load balancing with multiple strategies
+- **`@nexuskit/zookeeper`**: ZooKeeper integration for service discovery and registry
 
 ## 🛠️ Technology Stack
 
-| Component            | Technology | Version |
-| -------------------- | ---------- | ------- |
-| **Runtime**          | Node.js    | 18+     |
-| **Framework**        | NestJS     | 10.0+   |
-| **Language**         | TypeScript | 5.0+    |
-| **Build System**     | Nx         | 17.0+   |
+| Component            | Technology       | Version    |
+| -------------------- | ---------------- | ---------- |
+| **Runtime**          | Node.js          | 18+        |
+| **Framework**        | NestJS           | 10.0+      |
+| **Language**         | TypeScript       | 5.0+       |
+| **Build System**     | Nx               | 17.0+      |
 | **Service Registry** | Consul/ZooKeeper | 1.21+/3.8+ |
-| **HTTP Client**      | Got        | 11.8.2  |
-| **Testing**          | Jest       | 29.0+   |
-| **Linting**          | ESLint     | 8.0+    |
-| **Formatting**       | Prettier   | 3.0+    |
+| **HTTP Client**      | Got              | 11.8.2     |
+| **Testing**          | Jest             | 29.0+      |
+| **Linting**          | ESLint           | 8.0+       |
+| **Formatting**       | Prettier         | 3.0+       |
 
 ## 📦 Installation
 
@@ -203,12 +203,12 @@ The project includes powerful scripts for managing multiple service instances:
 
    ```typescript
    import { Module } from '@nestjs/common';
-   import { BootstrapModule } from '@swft-mt/bootstrap';
-   import { ClientModule } from '@swft-mt/client';
-   import { CloudModule } from '@swft-mt/cloud';
-   import { ConsulModule } from '@swft-mt/consul';
-   import { ZookeeperModule } from '@swft-mt/zookeeper';
-   import { LoadBalancerModule } from '@swft-mt/loadbalancer';
+   import { BootstrapModule } from '@nexuskit/bootstrap';
+   import { ClientModule } from '@nexuskit/client';
+   import { CloudModule } from '@nexuskit/cloud';
+   import { ConsulModule } from '@nexuskit/consul';
+   import { ZookeeperModule } from '@nexuskit/zookeeper';
+   import { LoadBalancerModule } from '@nexuskit/loadbalancer';
 
    @Module({
      imports: [
@@ -258,7 +258,7 @@ The project includes powerful scripts for managing multiple service instances:
 
 ```typescript
 import { Controller, Get } from '@nestjs/common';
-import { HttpClient, HttpServiceClient } from '@swft-mt/client';
+import { HttpClient, HttpServiceClient } from '@nexuskit/client';
 
 @Controller()
 export class AppController {
@@ -298,14 +298,14 @@ config:
 
 ### Environment Variables
 
-| Variable      | Description  | Default     |
-| ------------- | ------------ | ----------- |
-| `PORT`        | Service port | 3333        |
-| `NODE_ENV`    | Environment  | development |
-| `CONSUL_HOST` | Consul host  | localhost   |
-| `CONSUL_PORT` | Consul port  | 8500        |
-| `ZOOKEEPER_HOST` | ZooKeeper host | localhost |
-| `ZOOKEEPER_PORT` | ZooKeeper port | 2181 |
+| Variable         | Description    | Default     |
+| ---------------- | -------------- | ----------- |
+| `PORT`           | Service port   | 3333        |
+| `NODE_ENV`       | Environment    | development |
+| `CONSUL_HOST`    | Consul host    | localhost   |
+| `CONSUL_PORT`    | Consul port    | 8500        |
+| `ZOOKEEPER_HOST` | ZooKeeper host | localhost   |
+| `ZOOKEEPER_PORT` | ZooKeeper port | 2181        |
 
 ### Service Configuration
 
@@ -450,13 +450,13 @@ spec:
         app: service-1
     spec:
       containers:
-      - name: service-1
-        image: your-registry/service-1:latest
-        ports:
-        - containerPort: 3333
-        env:
-        - name: PORT
-          value: "3333"
+        - name: service-1
+          image: your-registry/service-1:latest
+          ports:
+            - containerPort: 3333
+          env:
+            - name: PORT
+              value: '3333'
 ```
 
 ## 🤝 Contributing

--- a/apps/service-1/src/app/app.controller.ts
+++ b/apps/service-1/src/app/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { HttpClient, HttpServiceClient } from '@swft-mt/client';
+import { HttpClient, HttpServiceClient } from '@nexuskit/client';
 import { AppService } from './app.service';
 
 @Controller()

--- a/apps/service-1/src/app/app.module.ts
+++ b/apps/service-1/src/app/app.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { BootstrapModule } from '@swft-mt/bootstrap';
-import { ClientModule } from '@swft-mt/client';
-import { CloudModule } from '@swft-mt/cloud';
-import { LoadBalancerModule } from '@swft-mt/loadbalancer';
-import { ZookeeperModule } from '@swft-mt/zookeeper';
+import { BootstrapModule } from '@nexuskit/bootstrap';
+import { ClientModule } from '@nexuskit/client';
+import { CloudModule } from '@nexuskit/cloud';
+import { LoadBalancerModule } from '@nexuskit/loadbalancer';
+import { ZookeeperModule } from '@nexuskit/zookeeper';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 

--- a/apps/service-1/src/app/app.service.ts
+++ b/apps/service-1/src/app/app.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { BootConfig } from '@swft-mt/bootstrap';
+import { BootConfig } from '@nexuskit/bootstrap';
 
 @Injectable()
 export class AppService {

--- a/apps/service-1/src/main.ts
+++ b/apps/service-1/src/main.ts
@@ -5,7 +5,7 @@
 
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { enableKillGracefully } from '@swft-mt/common';
+import { enableKillGracefully } from '@nexuskit/common';
 import { AppModule } from './app/app.module';
 
 async function bootstrap() {

--- a/apps/service-2/src/app/app.module.ts
+++ b/apps/service-2/src/app/app.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
-import { ClientModule } from '@swft-mt/client';
-import { CloudModule } from '@swft-mt/cloud';
-import { LoadBalancerModule } from '@swft-mt/loadbalancer';
-import { ZookeeperModule } from '@swft-mt/zookeeper';
+import { ClientModule } from '@nexuskit/client';
+import { CloudModule } from '@nexuskit/cloud';
+import { LoadBalancerModule } from '@nexuskit/loadbalancer';
+import { ZookeeperModule } from '@nexuskit/zookeeper';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 

--- a/apps/service-2/src/main.ts
+++ b/apps/service-2/src/main.ts
@@ -5,7 +5,7 @@
 
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { enableKillGracefully } from '@swft-mt/common';
+import { enableKillGracefully } from '@nexuskit/common';
 import { AppModule } from './app/app.module';
 
 async function bootstrap() {

--- a/libs/bootstrap/project.json
+++ b/libs/bootstrap/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swft-mt/bootstrap",
+  "name": "@nexuskit/bootstrap",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/bootstrap/src",
   "projectType": "library",

--- a/libs/bootstrap/src/lib/boot-config-file.loader.ts
+++ b/libs/bootstrap/src/lib/boot-config-file.loader.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { stringToObjectType } from '@swft-mt/common';
+import { stringToObjectType } from '@nexuskit/common';
 import { existsSync, readFileSync } from 'fs';
 import { basename, dirname, resolve, toNamespacedPath } from 'path';
 import { BOOTSTRAP_CONFIGURATION_OPTIONS } from './bootstrap.constants';
@@ -12,7 +12,7 @@ export class BootConfigFileLoader {
 
   constructor(
     @Inject(BOOTSTRAP_CONFIGURATION_OPTIONS)
-    private readonly options: BootstrapModuleOptions
+    private readonly options: BootstrapModuleOptions,
   ) {
     this.files = this.getFilesPath();
   }

--- a/libs/client/project.json
+++ b/libs/client/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swft-mt/client",
+  "name": "@nexuskit/client",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/client/src",
   "projectType": "library",

--- a/libs/client/src/lib/client-orchestrator.ts
+++ b/libs/client/src/lib/client-orchestrator.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
-import { LoadBalancerClient } from '@swft-mt/loadbalancer';
+import { LoadBalancerClient } from '@nexuskit/loadbalancer';
 import { ClientFactory } from './client.factory';
 import { Client } from './interfaces';
 import { ClientMetadata } from './interfaces/client-metadata.interface';

--- a/libs/client/src/lib/client.factory.ts
+++ b/libs/client/src/lib/client.factory.ts
@@ -1,4 +1,4 @@
-import { LoadBalancerClient } from '@swft-mt/loadbalancer';
+import { LoadBalancerClient } from '@nexuskit/loadbalancer';
 import { ClientOptions } from './interfaces';
 import { HttpClient } from './transports/http.client';
 

--- a/libs/client/src/lib/decorators/http-service.decorator.ts
+++ b/libs/client/src/lib/decorators/http-service.decorator.ts
@@ -1,11 +1,11 @@
 import { applyDecorators } from '@nestjs/common';
-import { ExtendMetadata } from '@swft-mt/common';
+import { ExtendMetadata } from '@nexuskit/common';
 import { HTTP_CLIENT_SERVICE } from 'libs/client/src/lib/client.constants';
 import { IHttpServiceClient } from '../interfaces';
 
 export function HttpServiceClient(
   name: string,
-  options?: Omit<IHttpServiceClient, 'transport'>
+  options?: Omit<IHttpServiceClient, 'transport'>,
 ) {
   return applyDecorators((target, property) => {
     return ExtendMetadata(HTTP_CLIENT_SERVICE, {

--- a/libs/client/src/lib/transports/http.client.ts
+++ b/libs/client/src/lib/transports/http.client.ts
@@ -1,6 +1,9 @@
 import { Logger } from '@nestjs/common';
-import { ServiceInstance } from '@swft-mt/common';
-import { LoadBalancerClient, LoadBalancerRequest } from '@swft-mt/loadbalancer';
+import { ServiceInstance } from '@nexuskit/common';
+import {
+  LoadBalancerClient,
+  LoadBalancerRequest,
+} from '@nexuskit/loadbalancer';
 import got, * as Got from 'got';
 import { merge } from 'lodash';
 import { HttpGotOptions, IHttpServiceClient } from '../interfaces';

--- a/libs/cloud/project.json
+++ b/libs/cloud/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swft-mt/cloud",
+  "name": "@nexuskit/cloud",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/cloud/src",
   "projectType": "library",

--- a/libs/cloud/src/lib/interfaces/registry-options.interface.ts
+++ b/libs/cloud/src/lib/interfaces/registry-options.interface.ts
@@ -1,4 +1,4 @@
-import { DiscoveryOptions, Service } from '@swft-mt/common';
+import { DiscoveryOptions, Service } from '@nexuskit/common';
 import { HeartbeatOptions } from './heartbeat-options.interface';
 
 export interface BaseRegistryOption {

--- a/libs/cloud/src/lib/utils/provider.util.ts
+++ b/libs/cloud/src/lib/utils/provider.util.ts
@@ -1,6 +1,6 @@
 import { Provider } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
-import { SERVICE_REGISTRY_CONFIG, ServiceStore } from '@swft-mt/common';
+import { SERVICE_REGISTRY_CONFIG, ServiceStore } from '@nexuskit/common';
 import { RegistryConfiguration } from '../interfaces';
 import { validateRegistryOptions } from './validate-registry-options.util';
 
@@ -16,7 +16,7 @@ export function getSharedProviderUtils(
   };
 
   if (registryOption.discoverer === 'consul') {
-    const { ConsulServiceRegistry } = require('@swft-mt/consul');
+    const { ConsulServiceRegistry } = require('@nexuskit/consul');
 
     configProvider.useValue = {
       service: registryOption.service,
@@ -30,9 +30,9 @@ export function getSharedProviderUtils(
     sharedProviders.push(ConsulServiceRegistry);
   } else if (registryOption.discoverer === 'zookeeper') {
     const importPackage = loadPackage(
-      '@swft-mt/zookeeper',
-      '@swft-mt/common',
-      () => require('@swft-mt/zookeeper'),
+      '@nexuskit/zookeeper',
+      '@nexuskit/common',
+      () => require('@nexuskit/zookeeper'),
     );
 
     configProvider.useValue = {

--- a/libs/common/project.json
+++ b/libs/common/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swft-mt/common",
+  "name": "@nexuskit/common",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/common/src",
   "projectType": "library",

--- a/libs/common/src/lib/client/default-service.instance.ts
+++ b/libs/common/src/lib/client/default-service.instance.ts
@@ -2,7 +2,7 @@ import {
   PlainObject,
   ServiceInstance,
   ServiceInstanceState,
-} from '@swft-mt/common';
+} from '@nexuskit/common';
 import { ServiceInstanceOptions } from './service-instance.options';
 
 export class DefaultServiceInstance implements ServiceInstance {
@@ -62,7 +62,7 @@ export class DefaultServiceInstance implements ServiceInstance {
     if (this.opts.metadata instanceof Map) {
       return Object.fromEntries(this.opts.metadata);
     }
-    
+
     return this.opts.metadata || {};
   }
 }

--- a/libs/common/src/lib/client/default-service.instance.ts
+++ b/libs/common/src/lib/client/default-service.instance.ts
@@ -1,8 +1,6 @@
-import {
-  PlainObject,
-  ServiceInstance,
-  ServiceInstanceState,
-} from '@nexuskit/common';
+import { ServiceInstanceState } from '../health';
+import { ServiceInstance } from '../interfaces';
+import { PlainObject } from '../utils';
 import { ServiceInstanceOptions } from './service-instance.options';
 
 export class DefaultServiceInstance implements ServiceInstance {

--- a/libs/consul/project.json
+++ b/libs/consul/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swft-mt/consul",
+  "name": "@nexuskit/consul",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/consul/src",
   "projectType": "library",

--- a/libs/consul/src/lib/consul.client.ts
+++ b/libs/consul/src/lib/consul.client.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { IReactiveClient } from '@swft-mt/common';
+import { IReactiveClient } from '@nexuskit/common';
 import * as Consul from 'consul';
 import {
   Acl,
@@ -17,7 +17,8 @@ import { ConsulConfig } from './consul.config';
 
 @Injectable()
 export class ConsulClient
-  implements IReactiveClient<Consul.Consul>, Consul.Consul, OnModuleInit {
+  implements IReactiveClient<Consul.Consul>, Consul.Consul, OnModuleInit
+{
   public consul: Consul.Consul;
 
   acl: Acl;
@@ -66,7 +67,7 @@ export class ConsulClient
       Logger.log('Consul Client starting...');
 
       // Create the consul instance
-      this.consul = Consul({
+      this.consul = new Consul.default({
         ...this.options.config,
         promisify: true,
       });

--- a/libs/consul/src/lib/consul.config.ts
+++ b/libs/consul/src/lib/consul.config.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, OnModuleInit, Optional } from '@nestjs/common';
-import { BootConfig } from '@swft-mt/bootstrap';
+import { BootConfig } from '@nexuskit/bootstrap';
 import { isEmpty, isPlainObject, merge } from 'lodash';
 import { CONSUL_CONFIG_OPTIONS } from './consul.constants';
 import { ConsulModuleOptions } from './interfaces/consul-module.options';
@@ -11,7 +11,7 @@ export class ConsulConfig implements OnModuleInit {
 
   constructor(
     @Inject(CONSUL_CONFIG_OPTIONS) private opts: ConsulModuleOptions,
-    @Optional() private readonly bootConfig: BootConfig
+    @Optional() private readonly bootConfig: BootConfig,
   ) {}
 
   get config(): ConsulModuleOptions {
@@ -23,7 +23,7 @@ export class ConsulConfig implements OnModuleInit {
     if (this.bootConfig) {
       _tempConfig = this.bootConfig.get<ConsulModuleOptions>(
         this.CONFIG_PREFIX,
-        this.opts
+        this.opts,
       );
     }
 
@@ -33,7 +33,7 @@ export class ConsulConfig implements OnModuleInit {
 
     if (!isPlainObject(this.options) || isEmpty(this.options)) {
       throw new Error(
-        'consul configuration is missing in bootstrap and module config'
+        'consul configuration is missing in bootstrap and module config',
       );
     }
   }

--- a/libs/consul/src/lib/default-service-instance.ts
+++ b/libs/consul/src/lib/default-service-instance.ts
@@ -2,7 +2,7 @@ import {
   PlainObject,
   ServiceInstance,
   ServiceInstanceState,
-} from '@swft-mt/common';
+} from '@nexuskit/common';
 import { ServiceInstanceOptions } from './interfaces/service-instance-options';
 
 export class DefaultServiceInstance implements ServiceInstance {

--- a/libs/consul/src/lib/interfaces/consul-discovery.options.ts
+++ b/libs/consul/src/lib/interfaces/consul-discovery.options.ts
@@ -1,4 +1,4 @@
-import { DiscoveryOptions } from '@swft-mt/common';
+import { DiscoveryOptions } from '@nexuskit/common';
 
 type ConsulDiscoveryOption = {
   scheme?: string;

--- a/libs/consul/src/lib/interfaces/consul-module.options.ts
+++ b/libs/consul/src/lib/interfaces/consul-module.options.ts
@@ -1,4 +1,4 @@
-import { BaseClientOptions } from '@swft-mt/common';
+import { BaseClientOptions } from '@nexuskit/common';
 import { ConsulOptions } from 'consul';
 
 export interface ConsulModuleOptions extends ConsulOptions, BaseClientOptions {

--- a/libs/consul/src/lib/interfaces/consul-registry.options.ts
+++ b/libs/consul/src/lib/interfaces/consul-registry.options.ts
@@ -1,4 +1,4 @@
-import { HeartbeatOptions, Service } from '@swft-mt/common';
+import { HeartbeatOptions, Service } from '@nexuskit/common';
 import { ConsulDiscoveryOptions } from './consul-discovery.options';
 
 export interface ConsulRegistryOptions {

--- a/libs/consul/src/lib/interfaces/index.ts
+++ b/libs/consul/src/lib/interfaces/index.ts
@@ -3,7 +3,6 @@ export * from './consul-module.options';
 export * from './consul-registry.options';
 export * from './consul.interface';
 export * from './heartbeat-task.interface';
-export * from '../../../../common/src/lib/interfaces/heartbeat.interface';
 export * from './service-instance-options';
 export * from './service-instance.interface';
 export * from './service-registry-builder.interface';

--- a/libs/consul/src/lib/interfaces/service-instance-options.ts
+++ b/libs/consul/src/lib/interfaces/service-instance-options.ts
@@ -1,4 +1,4 @@
-import { ServiceInstanceState } from '@swft-mt/common';
+import { ServiceInstanceState } from '@nexuskit/common';
 
 /**
  * Service instance options

--- a/libs/consul/src/lib/interfaces/service-instance.interface.ts
+++ b/libs/consul/src/lib/interfaces/service-instance.interface.ts
@@ -1,4 +1,4 @@
-import { PlainObject } from '@swft-mt/common';
+import { PlainObject } from '@nexuskit/common';
 
 export interface ServiceInstance {
   /**

--- a/libs/consul/src/lib/interfaces/service-registry-builder.interface.ts
+++ b/libs/consul/src/lib/interfaces/service-registry-builder.interface.ts
@@ -1,4 +1,4 @@
-import { HeartbeatOptions, PlainObject, Registration } from '@swft-mt/common';
+import { HeartbeatOptions, PlainObject, Registration } from '@nexuskit/common';
 import { ConsulDiscoveryOptions } from './consul-discovery.options';
 
 export interface RegistrationBuilder {

--- a/libs/consul/src/lib/service-health/ttl-scheduler.ts
+++ b/libs/consul/src/lib/service-health/ttl-scheduler.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { HeartbeatOptions } from '@swft-mt/common';
+import { HeartbeatOptions } from '@nexuskit/common';
 import { HeartbeatTask } from '../interfaces';
 
 const tasks = new Map<string, any>();
@@ -7,7 +7,7 @@ const tasks = new Map<string, any>();
 export class TtlScheduler {
   constructor(
     private heartbeatOptions: HeartbeatOptions,
-    private task: HeartbeatTask
+    private task: HeartbeatTask,
   ) {}
 
   /**

--- a/libs/consul/src/lib/service-registry/consul-registration.builder.ts
+++ b/libs/consul/src/lib/service-registry/consul-registration.builder.ts
@@ -1,9 +1,8 @@
-import { IpUtils, PlainObject } from '@swft-mt/common';
+import { HeartbeatOptions, IpUtils, PlainObject } from '@nexuskit/common';
 import * as uuid from 'uuid';
 import {
   Check,
   ConsulDiscoveryOptions,
-  HeartbeatOptions,
   RegistrationBuilder,
   Service,
 } from '../interfaces';

--- a/libs/consul/src/lib/service-registry/consul-registration.ts
+++ b/libs/consul/src/lib/service-registry/consul-registration.ts
@@ -1,4 +1,4 @@
-import { PlainObject, Registration } from '@swft-mt/common';
+import { PlainObject, Registration } from '@nexuskit/common';
 import { ConsulDiscoveryOptions, Service } from '../interfaces';
 
 export class ConsulRegistration implements Registration<Service> {

--- a/libs/consul/src/lib/service-registry/consul-service-registry.ts
+++ b/libs/consul/src/lib/service-registry/consul-service-registry.ts
@@ -9,7 +9,7 @@ import {
   Registration,
   SERVICE_REGISTRY_CONFIG,
   ServiceStore,
-} from '@swft-mt/common';
+} from '@nexuskit/common';
 import * as consul from 'consul';
 import * as Consul from 'consul';
 import { Watch } from 'consul';

--- a/libs/consul/src/lib/utils/consul.utils.ts
+++ b/libs/consul/src/lib/utils/consul.utils.ts
@@ -1,8 +1,8 @@
-import { ServiceInstance, ServiceStatus } from '@swft-mt/common';
+import { ServiceInstance, ServiceStatus } from '@nexuskit/common';
 import { ConsulServiceInstance } from '../service-discovery/consul-service.instance';
 
 export function consulServiceToServiceInstance(
-  nodes: any[]
+  nodes: any[],
 ): ServiceInstance[] {
   const serviceInstances: ConsulServiceInstance[] = [];
   for (const node of nodes) {
@@ -34,7 +34,7 @@ export function consulServiceToServiceInstance(
         secure: node.Service.Meta.Secure || false,
         serviceId: node.Service.Service,
         tags: node.Service.Tags,
-      })
+      }),
     );
   }
 

--- a/libs/consul/tsconfig.lib.json
+++ b/libs/consul/tsconfig.lib.json
@@ -8,5 +8,5 @@
     "target": "es2021"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["src/**/*.ts", "../common/src/lib/interfaces/registration.interface.ts", "../common/src/lib/interfaces/heartbeat.interface.ts", "../common/src/lib/utils/sleep.util.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/libs/loadbalancer/project.json
+++ b/libs/loadbalancer/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swft-mt/loadbalancer",
+  "name": "@nexuskit/loadbalancer",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/loadbalancer/src",
   "projectType": "library",

--- a/libs/loadbalancer/src/lib/decorators/loadbalancer-strategy.decorator.ts
+++ b/libs/loadbalancer/src/lib/decorators/loadbalancer-strategy.decorator.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { getMetadataStorage } from '@swft-mt/common';
+import { getMetadataStorage } from '@nexuskit/common';
 import 'reflect-metadata';
 
 export function LoadBalancerStrategy(name?: string): ClassDecorator {

--- a/libs/loadbalancer/src/lib/interfaces/loadbalancer-client.interface.ts
+++ b/libs/loadbalancer/src/lib/interfaces/loadbalancer-client.interface.ts
@@ -1,4 +1,4 @@
-import { ServiceInstance } from '@swft-mt/common';
+import { ServiceInstance } from '@nexuskit/common';
 import { LoadBalancerRequest } from '../core/loadbalancer.request';
 
 export interface ILoadBalancerClient {
@@ -23,6 +23,6 @@ export interface ILoadBalancerClient {
   execute<T>(
     serviceId: string,
     node: ServiceInstance,
-    request: LoadBalancerRequest<T>
+    request: LoadBalancerRequest<T>,
   ): T;
 }

--- a/libs/loadbalancer/src/lib/interfaces/service-instance-chooser.interface.ts
+++ b/libs/loadbalancer/src/lib/interfaces/service-instance-chooser.interface.ts
@@ -1,4 +1,4 @@
-import { ServiceInstance } from '@swft-mt/common';
+import { ServiceInstance } from '@nexuskit/common';
 import { BaseStrategy } from '..//base.strategy';
 
 export interface ServiceInstanceChooser {

--- a/libs/loadbalancer/src/lib/loadbalancer.client.ts
+++ b/libs/loadbalancer/src/lib/loadbalancer.client.ts
@@ -4,7 +4,7 @@ import {
   ServerCriticalException,
   ServiceInstance,
   ServiceStore,
-} from '@swft-mt/common';
+} from '@nexuskit/common';
 import { BaseStrategy } from './base.strategy';
 import { LoadBalancerRequest } from './core/loadbalancer.request';
 import { ILoadBalancerClient } from './interfaces/loadbalancer-client.interface';
@@ -15,7 +15,8 @@ import { StrategyRegistry } from './strategy.registry';
 
 @Injectable()
 export class LoadBalancerClient
-  implements ILoadBalancerClient, ServiceInstanceChooser, OnModuleInit {
+  implements ILoadBalancerClient, ServiceInstanceChooser, OnModuleInit
+{
   private readonly serviceStrategies = new Map<
     string,
     BaseStrategy<ServiceInstance>
@@ -24,7 +25,7 @@ export class LoadBalancerClient
   constructor(
     private readonly properties: LoadBalancerConfig,
     private readonly serviceStore: ServiceStore,
-    private readonly registry: StrategyRegistry
+    private readonly registry: StrategyRegistry,
   ) {}
 
   private init() {
@@ -44,7 +45,7 @@ export class LoadBalancerClient
 
       const strategyName = this.properties.getStrategy(service);
       const StrategyClass = this.registry.getStrategy(strategyName);
-      
+
       if (StrategyClass) {
         this.createStrategy(service, nodes, StrategyClass);
       }
@@ -54,13 +55,14 @@ export class LoadBalancerClient
   private createStrategy(
     serviceName: string,
     nodes: ServiceInstance[],
-    StrategyClass: any
+    StrategyClass: any,
   ) {
-    const strategyInstance = (new StrategyClass() as unknown) as BaseStrategy<ServiceInstance>;
+    const strategyInstance =
+      new StrategyClass() as unknown as BaseStrategy<ServiceInstance>;
 
     strategyInstance.init(
       serviceName,
-      new ServiceInstancePool(serviceName, nodes)
+      new ServiceInstancePool(serviceName, nodes),
     );
 
     this.serviceStrategies.set(serviceName, strategyInstance);
@@ -70,7 +72,7 @@ export class LoadBalancerClient
     const strategy = this.serviceStrategies.get(serviceId);
     if (!strategy) {
       throw new Error(
-        `service [${serviceId}] does not exist with loadbalance strategy`
+        `service [${serviceId}] does not exist with loadbalance strategy`,
       );
     }
 
@@ -90,12 +92,12 @@ export class LoadBalancerClient
   execute<T>(
     serviceId: string,
     node: ServiceInstance,
-    request: LoadBalancerRequest<T>
+    request: LoadBalancerRequest<T>,
   ): T;
   async execute<T>(
     serviceId: string,
     nodeOrRequest: LoadBalancerRequest<T> | ServiceInstance,
-    request?: LoadBalancerRequest<T>
+    request?: LoadBalancerRequest<T>,
   ): Promise<T> {
     if (!serviceId) {
       throw new Error('serviceId is missing');

--- a/libs/loadbalancer/src/lib/loadbalancer.config.ts
+++ b/libs/loadbalancer/src/lib/loadbalancer.config.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, OnModuleInit, Optional } from '@nestjs/common';
-import { BootConfig } from '@swft-mt/bootstrap';
+import { BootConfig } from '@nexuskit/bootstrap';
 import { isEmpty, isPlainObject, merge } from 'lodash';
 import { LoadBalancerModuleOptions } from './interfaces/loadbalancer-module-options.interface';
 import { LOAD_BALANCE_CONFIG_OPTIONS } from './loadbalancer.constants';
@@ -14,7 +14,7 @@ export class LoadBalancerConfig implements OnModuleInit {
   constructor(
     @Inject(LOAD_BALANCE_CONFIG_OPTIONS)
     private opts: LoadBalancerModuleOptions,
-    @Optional() private readonly bootConfig: BootConfig
+    @Optional() private readonly bootConfig: BootConfig,
   ) {}
 
   get config(): LoadBalancerModuleOptions {
@@ -46,7 +46,7 @@ export class LoadBalancerConfig implements OnModuleInit {
     if (this.bootConfig) {
       _tempConfig = this.bootConfig.get<LoadBalancerModuleOptions>(
         this.CONFIG_PREFIX,
-        this.opts
+        this.opts,
       );
     }
 
@@ -56,7 +56,7 @@ export class LoadBalancerConfig implements OnModuleInit {
 
     if (!isPlainObject(this.options) || isEmpty(this.options)) {
       throw new Error(
-        'loadbalancer configuration option is missing in bootstrap and module config'
+        'loadbalancer configuration option is missing in bootstrap and module config',
       );
     }
   }

--- a/libs/loadbalancer/src/lib/service-instance-pool.ts
+++ b/libs/loadbalancer/src/lib/service-instance-pool.ts
@@ -1,9 +1,9 @@
-import { ServiceInstance } from '@swft-mt/common';
+import { ServiceInstance } from '@nexuskit/common';
 
 export class ServiceInstancePool {
   constructor(
     private readonly serviceName: string,
-    private readonly nodes: Array<ServiceInstance & { weight?: number }>
+    private readonly nodes: Array<ServiceInstance & { weight?: number }>,
   ) {}
 
   get serviceId(): string {

--- a/libs/loadbalancer/src/lib/strategy.discovery.ts
+++ b/libs/loadbalancer/src/lib/strategy.discovery.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { ClassWithArgs, getMetadataStorage } from '@swft-mt/common';
+import { ClassWithArgs, getMetadataStorage } from '@nexuskit/common';
 import { StrategyRegistry } from './strategy.registry';
 
 @Injectable()

--- a/libs/loadbalancer/src/lib/strategy.registry.ts
+++ b/libs/loadbalancer/src/lib/strategy.registry.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ServiceInstance } from '@swft-mt/common';
+import { ServiceInstance } from '@nexuskit/common';
 import { BaseStrategy } from './base.strategy';
 
 @Injectable()

--- a/libs/loadbalancer/src/lib/strategy/random.strategy.ts
+++ b/libs/loadbalancer/src/lib/strategy/random.strategy.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ServiceInstance } from '@swft-mt/common';
+import { ServiceInstance } from '@nexuskit/common';
 import { LoadBalancerStrategy } from 'libs/loadbalancer/src/lib/decorators/loadbalancer-strategy.decorator';
 import { random } from 'lodash';
 import { BaseStrategy } from '../base.strategy';

--- a/libs/zookeeper/project.json
+++ b/libs/zookeeper/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "zookeeper",
+  "name": "@nexuskit/zookeeper",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/zookeeper/src",
   "projectType": "library",

--- a/libs/zookeeper/src/lib/discovery/zookeeper-discovery.client.ts
+++ b/libs/zookeeper/src/lib/discovery/zookeeper-discovery.client.ts
@@ -1,5 +1,9 @@
 import { Logger } from '@nestjs/common';
-import { DiscoveryClient, PlainObject, ServiceInstance } from '@swft-mt/common';
+import {
+  DiscoveryClient,
+  PlainObject,
+  ServiceInstance,
+} from '@nexuskit/common';
 import { flatten } from 'lodash';
 import { ZookeeperClient } from '../zookeeper.client';
 import { ZookeeperServiceInstance } from './zookeeper-service.instance';

--- a/libs/zookeeper/src/lib/discovery/zookeeper-heartbeat.task.ts
+++ b/libs/zookeeper/src/lib/discovery/zookeeper-heartbeat.task.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { HeartbeatTask } from '@swft-mt/common';
+import { HeartbeatTask } from '@nexuskit/common';
 import { ZookeeperClient } from '../zookeeper.client';
 
 export class ZookeeperHeartbeatTask implements HeartbeatTask {

--- a/libs/zookeeper/src/lib/discovery/zookeeper-service.instance.ts
+++ b/libs/zookeeper/src/lib/discovery/zookeeper-service.instance.ts
@@ -1,3 +1,3 @@
-import { DefaultServiceInstance } from '@swft-mt/common';
+import { DefaultServiceInstance } from '@nexuskit/common';
 
 export class ZookeeperServiceInstance extends DefaultServiceInstance {}

--- a/libs/zookeeper/src/lib/service-registry/zookeeper-discovery.options.ts
+++ b/libs/zookeeper/src/lib/service-registry/zookeeper-discovery.options.ts
@@ -1,4 +1,4 @@
-import { DiscoveryOptions } from '@swft-mt/common';
+import { DiscoveryOptions } from '@nexuskit/common';
 
 type ZookeeperDiscoveryOption = {
   scheme?: string;

--- a/libs/zookeeper/src/lib/service-registry/zookeeper-registration.builder.spec.ts
+++ b/libs/zookeeper/src/lib/service-registry/zookeeper-registration.builder.spec.ts
@@ -1,4 +1,4 @@
-import { HeartbeatOptions } from '@swft-mt/common';
+import { HeartbeatOptions } from '@nexuskit/common';
 import { ZookeeperDiscoveryOptions } from './zookeeper-discovery.options';
 import { ZookeeperRegistrationBuilder } from './zookeeper-registration.builder';
 

--- a/libs/zookeeper/src/lib/service-registry/zookeeper-registration.builder.ts
+++ b/libs/zookeeper/src/lib/service-registry/zookeeper-registration.builder.ts
@@ -3,7 +3,7 @@ import {
   PlainObject,
   RegistrationBuilder,
   Service,
-} from '@swft-mt/common';
+} from '@nexuskit/common';
 import * as uuid from 'uuid';
 import { ZookeeperDiscoveryOptions } from './zookeeper-discovery.options';
 import { ZookeeperRegistration } from './zookeeper-registration';

--- a/libs/zookeeper/src/lib/service-registry/zookeeper-registration.ts
+++ b/libs/zookeeper/src/lib/service-registry/zookeeper-registration.ts
@@ -1,4 +1,4 @@
-import { PlainObject, Registration, Service } from '@swft-mt/common';
+import { PlainObject, Registration, Service } from '@nexuskit/common';
 import { ZookeeperDiscoveryOptions } from './zookeeper-discovery.options';
 
 export class ZookeeperRegistration implements Registration<Service> {

--- a/libs/zookeeper/src/lib/service-registry/zookeeper-registry.options.ts
+++ b/libs/zookeeper/src/lib/service-registry/zookeeper-registry.options.ts
@@ -1,4 +1,4 @@
-import { HeartbeatOptions, Service } from '@swft-mt/common';
+import { HeartbeatOptions, Service } from '@nexuskit/common';
 import { ZookeeperDiscoveryOptions } from './zookeeper-discovery.options';
 
 export interface ZookeeperRegistryOptions {

--- a/libs/zookeeper/src/lib/service-registry/zookeeper-service-registry.spec.ts
+++ b/libs/zookeeper/src/lib/service-registry/zookeeper-service-registry.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { HeartbeatOptions, ServiceStore } from '@swft-mt/common';
+import { HeartbeatOptions, ServiceStore } from '@nexuskit/common';
 import ZooKeeper from 'zookeeper';
 import { ZookeeperClient } from '../zookeeper.client';
 import { ZookeeperDiscoveryOptions } from './zookeeper-discovery.options';
@@ -8,8 +8,8 @@ import { ZookeeperServiceRegistry } from './zookeeper-service-registry';
 
 // Mock the Zookeeper client
 jest.mock('../zookeeper.client');
-jest.mock('@swft-mt/common', () => ({
-  ...jest.requireActual('@swft-mt/common'),
+jest.mock('@nexuskit/common', () => ({
+  ...jest.requireActual('@nexuskit/common'),
   sleep: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/libs/zookeeper/src/lib/service-registry/zookeeper-service-registry.ts
+++ b/libs/zookeeper/src/lib/service-registry/zookeeper-service-registry.ts
@@ -13,7 +13,7 @@ import {
   ServiceStore,
   TtlScheduler,
   sleep,
-} from '@swft-mt/common';
+} from '@nexuskit/common';
 import ZooKeeper from 'zookeeper';
 import { ZookeeperHeartbeatTask } from '../discovery/zookeeper-heartbeat.task';
 import { ZookeeperClient } from '../zookeeper.client';

--- a/libs/zookeeper/src/lib/zookeeper-module.options.ts
+++ b/libs/zookeeper/src/lib/zookeeper-module.options.ts
@@ -1,4 +1,4 @@
-import { BaseClientOptions } from '@swft-mt/common';
+import { BaseClientOptions } from '@nexuskit/common';
 
 export interface ZookeeperModuleOptions extends BaseClientOptions {
   host: string;

--- a/libs/zookeeper/src/lib/zookeeper.client.ts
+++ b/libs/zookeeper/src/lib/zookeeper.client.ts
@@ -4,7 +4,7 @@ import {
   Logger,
   OnModuleInit,
 } from '@nestjs/common';
-import { handleRetry } from '@swft-mt/common';
+import { handleRetry } from '@nexuskit/common';
 import { merge } from 'lodash';
 import { defer, EMPTY, lastValueFrom } from 'rxjs';
 import ZooKeeper from 'zookeeper';

--- a/libs/zookeeper/src/lib/zookeeper.config.ts
+++ b/libs/zookeeper/src/lib/zookeeper.config.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, OnModuleInit, Optional } from '@nestjs/common';
-import { BootConfig } from '@swft-mt/bootstrap';
+import { BootConfig } from '@nexuskit/bootstrap';
 import { isEmpty, isPlainObject, merge } from 'lodash';
 import { ZookeeperModuleOptions } from './zookeeper-module.options';
 import { ZOOKEEPER_CONFIG_OPTIONS } from './zookeeper.constant';

--- a/libs/zookeeper/src/lib/zookeeper.integration.spec.ts
+++ b/libs/zookeeper/src/lib/zookeeper.integration.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { ServiceStore } from '@swft-mt/common';
+import { ServiceStore } from '@nexuskit/common';
 import { ZookeeperDiscoveryClient } from './discovery/zookeeper-discovery.client';
 import { ZookeeperServiceRegistry } from './service-registry/zookeeper-service-registry';
 import { ZookeeperModuleOptions } from './zookeeper-module.options';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,13 +15,13 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {
-      "@swft-mt/bootstrap": ["libs/bootstrap/src/index.ts"],
-      "@swft-mt/client": ["libs/client/src/index.ts"],
-      "@swft-mt/cloud": ["libs/cloud/src/index.ts"],
-      "@swft-mt/common": ["libs/common/src/index.ts"],
-      "@swft-mt/consul": ["libs/consul/src/index.ts"],
-      "@swft-mt/loadbalancer": ["libs/loadbalancer/src/index.ts"],
-      "@swft-mt/zookeeper": ["libs/zookeeper/src/index.ts"]
+      "@nexuskit/bootstrap": ["libs/bootstrap/src/index.ts"],
+      "@nexuskit/client": ["libs/client/src/index.ts"],
+      "@nexuskit/cloud": ["libs/cloud/src/index.ts"],
+      "@nexuskit/common": ["libs/common/src/index.ts"],
+      "@nexuskit/consul": ["libs/consul/src/index.ts"],
+      "@nexuskit/loadbalancer": ["libs/loadbalancer/src/index.ts"],
+      "@nexuskit/zookeeper": ["libs/zookeeper/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "dist", "tmp"]


### PR DESCRIPTION
This pull request introduces a major rebranding of the project from `@swft-mt` to `@nexuskit`. It updates package names, imports, and references across the codebase and documentation to reflect the new branding. Additionally, minor formatting adjustments are made in the `README.md` file.

### Rebranding to `@nexuskit`:

* **Package Name Updates**:
  - Updated the `name` field in `project.json` files for all libraries to use the `@nexuskit` namespace. (`libs/bootstrap/project.json` [[1]](diffhunk://#diff-27303188954371ffef9d1c344e666ef3be54e2270b4ae79ff84390568218f0efL2-R2) `libs/client/project.json` [[2]](diffhunk://#diff-8fc3147393135325711158ab62315ee36a6c03265e5a27d73b43b88127a156a2L2-R2) `libs/cloud/project.json` [[3]](diffhunk://#diff-4e4ce8871b49710519443b6ccee0b6fa2bef82afef44ad7bcc761887d6a40bacL2-R2) `libs/common/project.json` [[4]](diffhunk://#diff-a3f9d7c67547c22f89ef9ee88e0ac6cd05bac467b7cb7e79d92178aa9300c705L2-R2) `libs/consul/project.json` [[5]](diffhunk://#diff-471b2c294cbde146709158b0ca22b03a81541ba95a8cf7c9ff2b44fedbb8473aL2-R2)

* **Import Path Updates**:
  - Updated all import paths in source files to replace `@swft-mt` with `@nexuskit`. (e.g., `apps/service-1/src/app/app.module.ts` [[1]](diffhunk://#diff-1b62c178b0218dbcd1812d9f4513851778df95f412645751f259feae020dd228L2-R6) `libs/client/src/lib/client-orchestrator.ts` [[2]](diffhunk://#diff-6e546e9c87bf0b0fe5badac42cfe1450a2bfb5e4b4b32f1b17e55162cdb2cbcdL2-R2) `libs/cloud/src/lib/utils/provider.util.ts` [[3]](diffhunk://#diff-e435cc57ae186b79768ae945323dd40ac6889080f918ec39a56fb3f40976c037L3-R3)

### Documentation Updates:

* **Project Branding**:
  - Changed the project name and description in the `README.md` from "Multi-Tenant Microservice Architecture" to "NexusKit: The Complete Microservices Toolkit".

* **Library References**:
  - Updated all library references in the `README.md` to use the new `@nexuskit` namespace. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206-R211) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L261-R261)

* **Formatting Fixes**:
  - Adjusted table formatting and indentation in the `README.md` for consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L302-R302) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L459-R459)

Resolves #12 